### PR TITLE
Add `isolate` option to `selection` to avoid handing off reactive expression

### DIFF
--- a/R/crosstalk.R
+++ b/R/crosstalk.R
@@ -365,11 +365,15 @@ SharedData <- R6Class(
     #'   selection based on a [shiny::plotOutput()] brush, then
     #'   `ownerId` should be the `outputId` of that `plotOutput`.
     #' @param key \code{lgl} Returns the selected keys instead of a logical vector
-    selection = function(value, ownerId = "", key = FALSE) {
+    selection = function(value, ownerId = "", key = FALSE, isolate = FALSE) {
       stopIfNotShiny("SharedData$selection() requires the shiny package")
 
       if (missing(value)) {
-        out <- private$.rv$selected
+        out <- if (isolate) {
+            shiny::isolate(private$.rv$selected)
+          } else {
+            private$.rv$selected
+          }
         if (key)
           out <- self$key()[out]
         return(out)


### PR DESCRIPTION
The selection method is sometimes useful to hand off as the `selection` argument to `DT::datatable`, however handing off the reactiveValues object causes a reactive loop violation causing the third selection to blink on/off repeatedly filling the Javascript console log with a "Violation" warning. By adding an `isolate` option this behavior can be avoided by wrapping the reactive output from `selection` in `isolate`

App that demonstrates this unwanted behavior:
```
ui <- fluidPage(

    # Application title
    titlePanel("Old Faithful Geyser Data"),

    # Sidebar with a slider input for number of bins
    sidebarLayout(
        sidebarPanel(
          shinyVirga::browser_ui()
        ),


        mainPanel(
          DT::DTOutput("dt"),
          DT::DTOutput("selected")
        )
    )
)


# Define server logic required to draw a histogram
server <- function(input, output) {
  isolate({
    dt_data <- crosstalk::SharedData$new(
      data = reactiveVal(mtcars)
    )

    s_data <- crosstalk::SharedData$new(
      data = reactiveVal(mtcars[0,])
    )
  })


  selection <- reactiveVal()
  observeEvent(input$dt_rows_selected, {
    nd <- dt_data$data()[input$dt_rows_selected, ]
    s_data$.__enclos_env__$private$.data(nd)
    s_data$selection(1:nrow(nd))
  })

  output$dt <- DT::renderDT({
      # generate bins based on input$bins from ui.R
      DT::datatable(dt_data)
    }, server = FALSE)
  output$selected <- DT::renderDT({
      # generate bins based on input$bins from ui.R
      DT::datatable(s_data,
                    selection = list(
                      mode = "multiple",
                      selected = which(s_data$selection(isolate = TRUE) %||% FALSE),
                      target = "row")
                    )
    }, server = FALSE)
  shinyVirga::browser_server()
}

# Run the application
shinyApp(ui = ui, server = server)
```